### PR TITLE
Remap lite pose stream to MediaPipe indices

### DIFF
--- a/docs/pose_lite_mapping.md
+++ b/docs/pose_lite_mapping.md
@@ -1,0 +1,28 @@
+# Mapeo de articulaciones del stream «lite»
+
+El backend expone un stream de pose «lite» que sólo incluye las articulaciones
+necesarias para validar hombros, codos, muñecas, caderas, rodillas y tobillos.
+La siguiente tabla documenta el orden exacto en el que llegan esos puntos y la
+correspondencia con los índices oficiales de MediaPipe Pose (versión de 33
+landmarks):
+
+| `liteIndex` | Articulación           | `mediaPipeIndex` |
+|------------:|------------------------|-----------------:|
+| 0           | Hombro izquierdo       | 11 |
+| 1           | Hombro derecho         | 12 |
+| 2           | Codo izquierdo         | 13 |
+| 3           | Codo derecho           | 14 |
+| 4           | Muñeca izquierda       | 15 |
+| 5           | Muñeca derecha         | 16 |
+| 6           | Cadera izquierda       | 23 |
+| 7           | Cadera derecha         | 24 |
+| 8           | Rodilla izquierda      | 25 |
+| 9           | Rodilla derecha        | 26 |
+| 10          | Tobillo izquierdo      | 27 |
+| 11          | Tobillo derecho        | 28 |
+
+Todos los remapeos de este PR rellenan arreglos de 33 puntos (MediaPipe Pose
+completo) con `NaN` y escriben cada punto del stream «lite» en la posición que
+le corresponde según esta tabla. De este modo se preserva la compatibilidad con
+las métricas existentes (que esperan índices MediaPipe) y con los overlays en
+la UI.

--- a/lib/apps/asistente_retratos/domain/metrics/pose_geometry.dart
+++ b/lib/apps/asistente_retratos/domain/metrics/pose_geometry.dart
@@ -73,6 +73,10 @@ double? calcularAnguloHombros(
   if (puntosPose.length > maxIndex) {
     final izq = puntosPose[idxHombroIzq];
     final der = puntosPose[idxHombroDer];
+    if (!izq.dx.isFinite || !izq.dy.isFinite ||
+        !der.dx.isFinite || !der.dy.isFinite) {
+      return null;
+    }
     final dy = izq.dy - der.dy;
     final dx = izq.dx - der.dx;
     return math.atan2(dy, dx) * 180.0 / math.pi; // (-180..180]
@@ -98,6 +102,7 @@ double? estimateAzimutBiacromial3D({
   final double? rz = (rs.z as num?)?.toDouble();
   final double? lz = (ls.z as num?)?.toDouble();
   if (rx == null || lx == null || rz == null || lz == null) return null;
+  if (rx.isNaN || lx.isNaN || rz.isNaN || lz.isNaN) return null;
 
   final double dxPx = (rx - lx).abs();
   if (dxPx <= 1e-6) return 0.0;

--- a/lib/apps/asistente_retratos/presentation/widgets/pose_landmarks_painter.dart
+++ b/lib/apps/asistente_retratos/presentation/widgets/pose_landmarks_painter.dart
@@ -215,8 +215,18 @@ class PosePainter extends CustomPainter {
           final a = e[0], b = e[1];
           if (a < count && b < count) {
             final i0 = a << 1, i1 = b << 1;
-            final ax = mapX(p[i0]);     final ay = mapY(p[i0 + 1]);
-            final bx = mapX(p[i1]);     final by = mapY(p[i1 + 1]);
+            final double axRaw = p[i0];
+            final double ayRaw = p[i0 + 1];
+            final double bxRaw = p[i1];
+            final double byRaw = p[i1 + 1];
+            if (!axRaw.isFinite || !ayRaw.isFinite ||
+                !bxRaw.isFinite || !byRaw.isFinite) {
+              continue;
+            }
+            final ax = mapX(axRaw);
+            final ay = mapY(ayRaw);
+            final bx = mapX(bxRaw);
+            final by = mapY(byRaw);
             bones.moveTo(ax, ay);
             bones.lineTo(bx, by);
           }
@@ -224,7 +234,10 @@ class PosePainter extends CustomPainter {
       }
       if (showPoints) {
         for (int i = 0; i + 1 < p.length; i += 2) {
-          final cx = mapX(p[i]); final cy = mapY(p[i + 1]);
+          final double xRaw = p[i];
+          final double yRaw = p[i + 1];
+          if (!xRaw.isFinite || !yRaw.isFinite) continue;
+          final cx = mapX(xRaw); final cy = mapY(yRaw);
           dots.addOval(Rect.fromCircle(center: Offset(cx, cy), radius: r));
         }
       }


### PR DESCRIPTION
## Summary
- document the ordering of the backend "lite" pose stream and its mapping to MediaPipe indices
- remap incoming lite pose data into 33-landmark Float32List buffers before publishing 2D/3D frames and pose state
- harden the overlay painter and pose metrics so NaN placeholders are ignored and shoulder/azimuth angles read real joints

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d5b487e43883298822c3703d582915

## Summary by Sourcery

Remap the lightweight pose stream to MediaPipe's 33-landmark format with NaN placeholders for unmapped points, update service implementation to use new remapping functions, and harden UI painter and metric calculations to ignore non-finite values while adding documentation on the mapping.

New Features:
- Remap incoming lite pose stream into full 33-landmark Float32List buffers for 2D and 3D data
- Add documentation detailing the ordering and mapping of the lite pose stream to MediaPipe indices

Enhancements:
- Refactor PoseWebrtcService to leverage remapping functions and functional pipelines for scaling and 2D derivation
- Harden overlay painter to skip NaN or non-finite landmark coordinates
- Update PosePoint creation and pose geometry calculations to ignore non-finite values in angle computations

Documentation:
- Introduce pose_lite_mapping.md with a lite-to-MediaPipe landmark mapping table