### PR TITLE
Handle clamped pose landmarks as invalid

### DIFF
--- a/lib/apps/asistente_retratos/domain/metrics/pose_geometry.dart
+++ b/lib/apps/asistente_retratos/domain/metrics/pose_geometry.dart
@@ -73,6 +73,10 @@ double? calcularAnguloHombros(
   if (puntosPose.length > maxIndex) {
     final izq = puntosPose[idxHombroIzq];
     final der = puntosPose[idxHombroDer];
+    if (!izq.dx.isFinite || !izq.dy.isFinite ||
+        !der.dx.isFinite || !der.dy.isFinite) {
+      return null;
+    }
     final dy = izq.dy - der.dy;
     final dx = izq.dx - der.dx;
     return math.atan2(dy, dx) * 180.0 / math.pi; // (-180..180]
@@ -98,6 +102,7 @@ double? estimateAzimutBiacromial3D({
   final double? rz = (rs.z as num?)?.toDouble();
   final double? lz = (ls.z as num?)?.toDouble();
   if (rx == null || lx == null || rz == null || lz == null) return null;
+  if (!rx.isFinite || !lx.isFinite || !rz.isFinite || !lz.isFinite) return null;
 
   final double dxPx = (rx - lx).abs();
   if (dxPx <= 1e-6) return 0.0;

--- a/lib/apps/asistente_retratos/presentation/widgets/overlays.dart
+++ b/lib/apps/asistente_retratos/presentation/widgets/overlays.dart
@@ -131,6 +131,9 @@ class SkeletonPainter extends CustomPainter {
 
   // Reusable buffer for edge pairs (A,B,A,B,...)
   final List<Offset> _linePts = <Offset>[];
+  final List<Offset> _pointPts = <Offset>[];
+
+  bool _isFiniteOffset(Offset o) => o.dx.isFinite && o.dy.isFinite;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -178,10 +181,18 @@ class SkeletonPainter extends CustomPainter {
       if (pose.isEmpty) continue;
 
       _linePts.clear();
+      if (drawPoints) {
+        _pointPts.clear();
+      }
       for (final e in kPoseConnections) {
         final a = e[0], b = e[1];
         if (a < pose.length && b < pose.length) {
-          _linePts..add(pose[a])..add(pose[b]);
+          final pa = pose[a];
+          final pb = pose[b];
+          if (!_isFiniteOffset(pa) || !_isFiniteOffset(pb)) {
+            continue;
+          }
+          _linePts..add(pa)..add(pb);
         }
       }
       if (_linePts.isNotEmpty) {
@@ -189,7 +200,14 @@ class SkeletonPainter extends CustomPainter {
       }
 
       if (drawPoints) {
-        canvas.drawPoints(ui.PointMode.points, pose, dot);
+        for (final pt in pose) {
+          if (_isFiniteOffset(pt)) {
+            _pointPts.add(pt);
+          }
+        }
+        if (_pointPts.isNotEmpty) {
+          canvas.drawPoints(ui.PointMode.points, _pointPts, dot);
+        }
       }
     }
 

--- a/lib/apps/asistente_retratos/presentation/widgets/rtc_pose_overlay.dart
+++ b/lib/apps/asistente_retratos/presentation/widgets/rtc_pose_overlay.dart
@@ -113,14 +113,22 @@ class _PoseOverlayPainter extends CustomPainter {
       for (final e in _edges) {
         final i0 = e[0] * 2, i1 = e[1] * 2;
         if (p.length <= i0 + 1 || p.length <= i1 + 1) continue;
-        final ax = mapX(p[i0]),     ay = mapY(p[i0 + 1]);
-        final bx = mapX(p[i1]),     by = mapY(p[i1 + 1]);
+        final double axRaw = p[i0], ayRaw = p[i0 + 1];
+        final double bxRaw = p[i1], byRaw = p[i1 + 1];
+        if (!axRaw.isFinite || !ayRaw.isFinite ||
+            !bxRaw.isFinite || !byRaw.isFinite) {
+          continue;
+        }
+        final ax = mapX(axRaw), ay = mapY(ayRaw);
+        final bx = mapX(bxRaw), by = mapY(byRaw);
         bones.moveTo(ax, ay);
         bones.lineTo(bx, by);
       }
       // Puntos
       for (int i = 0; i + 1 < p.length; i += 2) {
-        final cx = mapX(p[i]), cy = mapY(p[i + 1]);
+        final double cxRaw = p[i], cyRaw = p[i + 1];
+        if (!cxRaw.isFinite || !cyRaw.isFinite) continue;
+        final cx = mapX(cxRaw), cy = mapY(cyRaw);
         dots.addOval(Rect.fromCircle(center: Offset(cx, cy), radius: r));
       }
     }
@@ -356,15 +364,23 @@ class _PoseOverlayFastPainter extends CustomPainter {
         for (final e in _edges) {
           final i0 = e[0] * 2, i1 = e[1] * 2;
           if (p.length <= i0 + 1 || p.length <= i1 + 1) continue;
-          final ax = mapX(p[i0]),     ay = mapY(p[i0 + 1]);
-          final bx = mapX(p[i1]),     by = mapY(p[i1 + 1]);
+          final double axRaw = p[i0], ayRaw = p[i0 + 1];
+          final double bxRaw = p[i1], byRaw = p[i1 + 1];
+          if (!axRaw.isFinite || !ayRaw.isFinite ||
+              !bxRaw.isFinite || !byRaw.isFinite) {
+            continue;
+          }
+          final ax = mapX(axRaw), ay = mapY(ayRaw);
+          final bx = mapX(bxRaw), by = mapY(byRaw);
           bones.moveTo(ax, ay);
           bones.lineTo(bx, by);
         }
       }
       if (showPoints) {
         for (int i = 0; i + 1 < p.length; i += 2) {
-          final cx = mapX(p[i]), cy = mapY(p[i + 1]);
+          final double cxRaw = p[i], cyRaw = p[i + 1];
+          if (!cxRaw.isFinite || !cyRaw.isFinite) continue;
+          final cx = mapX(cxRaw), cy = mapY(cyRaw);
           dots.addOval(Rect.fromCircle(center: Offset(cx, cy), radius: r));
         }
       }


### PR DESCRIPTION
## Summary
- mark clamped pose landmarks as invalid in both PosePacket and flat Float32List outputs so downstream consumers can detect them while preserving the quantized baseline
- skip drawing pose bones and points whenever mapped coordinates are not finite in the overlay painters
- guard shoulder and azimuth geometry helpers against invalid landmarks so portrait metrics ignore missing data

## Testing
- `flutter test` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cea170a48329a0296bbd65b01a5f

## Summary by Sourcery

Mark clamped pose landmarks as invalid by injecting NaN for out-of-range coordinates, skip rendering of non-finite points and edges, and guard pose geometry metrics against invalid data

Bug Fixes:
- Inject NaN for any clamped landmark coordinate in parser outputs
- Skip drawing pose bones and points when mapped coordinates are not finite
- Return null in shoulder-angle and azimuth helpers if any landmark coordinate is invalid