### PR TITLE
Remove JSON pose handling from WebRTC service

### DIFF
--- a/lib/apps/asistente_retratos/infrastructure/model/pose_frame.dart
+++ b/lib/apps/asistente_retratos/infrastructure/model/pose_frame.dart
@@ -87,33 +87,3 @@ class PoseFrame {
     );
   }
 }
-
-/// Convierte el JSON del servidor a PoseFrame.
-/// Espera: {"poses":[[{"x":..,"y":..,"px":..,"py":..}, ...], ...],
-///          "image_size":{"w":W,"h":H}}
-PoseFrame? poseFrameFromMap(Map<String, dynamic>? m) {
-  if (m == null) return null;
-  final img = m['image_size'] as Map<String, dynamic>?;
-  if (img == null) return null;
-
-  final w = (img['w'] as num).toDouble();
-  final h = (img['h'] as num).toDouble();
-
-  final rawPoses = (m['poses'] as List?) ?? const [];
-  final posesPx = <List<Offset>>[];
-
-  for (final p in rawPoses) {
-    final pts = <Offset>[];
-    for (final lm in (p as List)) {
-      final map = (lm as Map<String, dynamic>);
-      // Preferimos px/py; si no están, calculamos desde x,y normalizados
-      final px = (map['px'] ?? ((map['x'] as num?) ?? 0) * w) as num;
-      final py = (map['py'] ?? ((map['y'] as num?) ?? 0) * h) as num;
-      pts.add(Offset(px.toDouble(), py.toDouble()));
-    }
-    posesPx.add(pts);
-  }
-
-  // JSON → solo Offsets (ruta legacy); plano queda null.
-  return PoseFrame(imageSize: Size(w, h), posesPx: posesPx);
-}


### PR DESCRIPTION
## Summary
- drop the legacy JSON parsing branch from `PoseWebrtcServiceImp` and ignore any text data channel messages
- remove the unused `poseFrameFromMap` helper now that JSON pose handling is gone

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d861fd8a14832984bfc95bd66f09ef

## Summary by Sourcery

Remove legacy JSON pose handling from the WebRTC service and streamline data channel to only process binary messages

Enhancements:
- Streamline data channel handler to ignore text messages and only enqueue binary frames
- Remove legacy JSON parsing functions and the unused poseFrameFromMap helper