### PR TITLE
Refactor pose binary parsing to output packed buffers

### DIFF
--- a/lib/apps/asistente_retratos/infrastructure/parsers/pose_parse_isolate.dart
+++ b/lib/apps/asistente_retratos/infrastructure/parsers/pose_parse_isolate.dart
@@ -18,9 +18,10 @@
 //     "requestKF": bool,
 //     "keyframe": bool,
 //     "kind": "PO" | "PD",
-//     "poses": List<Float32List>,           // [x0,y0,x1,y1,...] por persona
-//     "hasZ": bool,                         // true si trae Z
-//     "posesZ": List<Float32List>?          // [z0,z1,...] por persona (normalizado), null si !hasZ
+//     "positions": Float32List,             // [x0,y0,x1,y1,...] packed por frame
+//     "ranges": Int32List,                  // [startPts,countPts,...] por persona
+//     "hasZ": bool,
+//     "zPositions": Float32List?            // [z0,z1,...] packed o null si !hasZ
 //   }
 //
 // SALIDA NEED_KF/ERROR: igual a antes.
@@ -62,23 +63,22 @@ void _handleJob(
 
     final res = parser.parseFlat2D(buf);
 
-    if (res is PoseParseOk2D) {
-      final pkt = res.packet;
-
+    if (res is PoseParseOkPacked) {
       reply.send(<String, dynamic>{
         'type': 'result',
         'status': 'ok',
         'task': task,
-        'w': pkt.w,
-        'h': pkt.h,
-        'seq': pkt.seq,
+        'w': res.w,
+        'h': res.h,
+        'seq': res.seq,
         'ackSeq': res.ackSeq,
         'requestKF': res.requestKeyframe,
-        'keyframe': pkt.keyframe,
-        'kind': pkt.kind == PacketKind.po ? 'PO' : 'PD',
-        'poses': pkt.poses2d,         // List<Float32List> XY
-        'hasZ': pkt.hasZ,             // bool
-        'posesZ': pkt.posesZ,         // List<Float32List>? Z normalizado o null
+        'keyframe': res.keyframe,
+        'kind': res.kind == PacketKind.po ? 'PO' : 'PD',
+        'positions': res.positions,
+        'ranges': res.ranges,
+        'hasZ': res.hasZ,
+        if (res.zPositions != null) 'zPositions': res.zPositions,
       });
       return;
     }


### PR DESCRIPTION
## Summary
- update `PoseBinaryParser` to emit packed position/range buffers without creating `PosePoint`/`Offset` objects
- route the WebRTC binary handler through the packed pipeline and remove the legacy pose emission helper
- adjust the parse isolate to forward the packed buffers to the main isolate

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d87feda3248329953adee20c16a042

## Summary by Sourcery

Refactor pose binary parsing to emit packed flat buffers for positions and ranges (with optional Z) and integrate the new pipeline into the WebRTC service and parse isolate, removing legacy object-based parsing and emission.

Enhancements:
- Convert PoseBinaryParser to output packed Float32List positions, Int32List ranges, and optional zPositions instead of creating PosePoint/Offset objects
- Replace old PoseParseOk and PosePacket types with a unified PoseParseOkPacked result and remove legacy parseFlat2D/emitBinary helpers
- Route PoseWebrtcServiceImp binary handler through the packed parsing pipeline and eliminate the legacy _emitBinary implementation
- Update the pose parse isolate to forward packed positions, ranges, and zPositions messages to the main isolate