### PR TITLE
Refactor pose overlays to use packed buffers

### DIFF
--- a/lib/apps/asistente_retratos/presentation/widgets/overlays.dart
+++ b/lib/apps/asistente_retratos/presentation/widgets/overlays.dart
@@ -130,8 +130,13 @@ class SkeletonPainter extends CustomPainter {
   final bool mirror;
   final BoxFit fit;
 
-  // Reusable buffer for edge pairs (A,B,A,B,...)
-  final List<Offset> _linePts = <Offset>[];
+  Float32List _lineBuf = Float32List(0);
+  Float32List _pointBuf = Float32List(0);
+  Float32List _scratch = Float32List(0);
+  int _lineFloats = 0;
+  int _pointFloats = 0;
+  final Map<int, Float32List> _lineViews = <int, Float32List>{};
+  final Map<int, Float32List> _pointViews = <int, Float32List>{};
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -152,9 +157,11 @@ class SkeletonPainter extends CustomPainter {
     final offY = (size.height - drawH) / 2.0;
 
     // Paints (sin antialias para rendimiento)
+    final double strokeScale = s <= 0 ? 1.0 : (1.0 / s);
+
     final line = Paint()
       ..color = color
-      ..strokeWidth = strokeWidth
+      ..strokeWidth = strokeWidth * strokeScale
       ..style = PaintingStyle.stroke
       ..strokeCap = StrokeCap.round
       ..isAntiAlias = false;
@@ -162,7 +169,7 @@ class SkeletonPainter extends CustomPainter {
     final dot = Paint()
       ..color = color
       ..style = PaintingStyle.stroke
-      ..strokeWidth = strokeWidth + 1.0
+      ..strokeWidth = (strokeWidth + 1.0) * strokeScale
       ..strokeCap = StrokeCap.round
       ..isAntiAlias = false;
 
@@ -175,6 +182,8 @@ class SkeletonPainter extends CustomPainter {
       canvas.scale(s, s);
     }
 
+    _resetBuffers();
+
     final Float32List? packedPos = frame.packedPositions;
     final Int32List? packedRanges = frame.packedRanges;
     final bool hasPacked =
@@ -182,55 +191,28 @@ class SkeletonPainter extends CustomPainter {
 
     if (hasPacked) {
       for (int i = 0; i + 1 < packedRanges!.length; i += 2) {
-        final int startPt = packedRanges[i];
-        final int countPt = packedRanges[i + 1];
-        if (countPt <= 0) continue;
-
-        _linePts.clear();
-        for (final e in kPoseConnections) {
-          final int a = e[0], b = e[1];
-          if (a >= countPt || b >= countPt) continue;
-          final int idxA = (startPt + a) << 1;
-          final int idxB = (startPt + b) << 1;
-          if (idxA + 1 >= packedPos!.length || idxB + 1 >= packedPos.length) {
-            continue;
-          }
-          final Offset pa = Offset(packedPos[idxA], packedPos[idxA + 1]);
-          final Offset pb = Offset(packedPos[idxB], packedPos[idxB + 1]);
-          _linePts..add(pa)..add(pb);
-        }
-        if (_linePts.isNotEmpty) {
-          canvas.drawPoints(ui.PointMode.lines, _linePts, line);
-        }
-
-        if (drawPoints) {
-          final int startF = startPt << 1;
-          final int endF = startF + (countPt << 1);
-          if (startF >= 0 && endF <= packedPos!.length) {
-            final Float32List view =
-                Float32List.sublistView(packedPos, startF, endF);
-            canvas.drawRawPoints(ui.PointMode.points, view, dot);
-          }
-        }
+        _appendPacked(packedPos!, packedRanges[i], packedRanges[i + 1],
+            includePoints: drawPoints);
+      }
+    } else if (frame.posesPxFlat != null && frame.posesPxFlat!.isNotEmpty) {
+      for (final Float32List flat in frame.posesPxFlat!) {
+        _appendFlat(flat, includePoints: drawPoints);
       }
     } else {
       for (final pose in frame.posesPx ?? const <List<Offset>>[]) {
-        if (pose.isEmpty) continue;
+        _appendOffsets(pose, includePoints: drawPoints);
+      }
+    }
 
-        _linePts.clear();
-        for (final e in kPoseConnections) {
-          final int a = e[0], b = e[1];
-          if (a < pose.length && b < pose.length) {
-            _linePts..add(pose[a])..add(pose[b]);
-          }
-        }
-        if (_linePts.isNotEmpty) {
-          canvas.drawPoints(ui.PointMode.lines, _linePts, line);
-        }
+    final Float32List? lineView = _lineView();
+    if (lineView != null) {
+      canvas.drawRawPoints(ui.PointMode.lines, lineView, line);
+    }
 
-        if (drawPoints) {
-          canvas.drawPoints(ui.PointMode.points, pose, dot);
-        }
+    if (drawPoints) {
+      final Float32List? pointView = _pointView();
+      if (pointView != null) {
+        canvas.drawRawPoints(ui.PointMode.points, pointView, dot);
       }
     }
 
@@ -245,6 +227,94 @@ class SkeletonPainter extends CustomPainter {
       old.drawPoints != drawPoints ||
       old.mirror != mirror ||
       old.fit != fit;
+
+  void _resetBuffers() {
+    _lineFloats = 0;
+    _pointFloats = 0;
+  }
+
+  void _ensureLineCapacity(int floats) {
+    if (_lineBuf.length >= floats) return;
+    _lineBuf = Float32List(floats);
+    _lineViews.clear();
+  }
+
+  void _ensurePointCapacity(int floats) {
+    if (_pointBuf.length >= floats) return;
+    _pointBuf = Float32List(floats);
+    _pointViews.clear();
+  }
+
+  Float32List _ensureScratch(int floats) {
+    if (_scratch.length >= floats) return _scratch;
+    _scratch = Float32List(floats);
+    return _scratch;
+  }
+
+  void _appendPacked(
+    Float32List src,
+    int startPt,
+    int countPt, {
+    required bool includePoints,
+  }) {
+    if (countPt <= 0) return;
+    final int startF = startPt << 1;
+    if (startF >= src.length) return;
+    int endF = startF + (countPt << 1);
+    if (endF > src.length) endF = src.length;
+    final int floats = endF - startF;
+    if (floats <= 0) return;
+    final int availablePts = floats >> 1;
+    if (availablePts <= 0) return;
+
+    _ensureLineCapacity(_lineFloats + kPoseConnections.length * 4);
+    for (final conn in kPoseConnections) {
+      final int a = conn[0], b = conn[1];
+      if (a >= availablePts || b >= availablePts) continue;
+      final int idxA = startF + (a << 1);
+      final int idxB = startF + (b << 1);
+      if (idxA + 1 >= endF || idxB + 1 >= endF) continue;
+      _lineBuf[_lineFloats++] = src[idxA];
+      _lineBuf[_lineFloats++] = src[idxA + 1];
+      _lineBuf[_lineFloats++] = src[idxB];
+      _lineBuf[_lineFloats++] = src[idxB + 1];
+    }
+
+    if (includePoints) {
+      _ensurePointCapacity(_pointFloats + floats);
+      _pointBuf.setRange(_pointFloats, _pointFloats + floats, src, startF);
+      _pointFloats += floats;
+    }
+  }
+
+  void _appendFlat(Float32List flat, {required bool includePoints}) {
+    if (flat.isEmpty) return;
+    _appendPacked(flat, 0, flat.length >> 1, includePoints: includePoints);
+  }
+
+  void _appendOffsets(List<Offset> pose, {required bool includePoints}) {
+    if (pose.isEmpty) return;
+    final int floats = pose.length << 1;
+    final Float32List scratch = _ensureScratch(floats);
+    int k = 0;
+    for (final Offset pt in pose) {
+      scratch[k++] = pt.dx;
+      scratch[k++] = pt.dy;
+    }
+    _appendPacked(scratch, 0, pose.length, includePoints: includePoints);
+  }
+
+  Float32List? _lineView() {
+    if (_lineFloats == 0) return null;
+    return _lineViews[_lineFloats] ??=
+        Float32List.view(_lineBuf.buffer, 0, _lineFloats);
+  }
+
+  Float32List? _pointView() {
+    if (_pointFloats == 0) return null;
+    return _pointViews[_pointFloats] ??=
+        Float32List.view(_pointBuf.buffer, 0, _pointFloats);
+  }
 }
 
 /// ───────────────────────── Overlay widget ─────────────────────────


### PR DESCRIPTION
## Summary
- rewrite the pose overlay painter to reuse packed pose buffers and draw with `Canvas.drawRawPoints`
- update the fast pose overlay to share typed list caches for pose and face rendering
- switch the skeleton painter to typed buffers for lines and points to avoid per-frame allocations

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d95fbef63c8329bf2fb28a7907fcb9

## Summary by Sourcery

Refactor pose overlay and skeleton painters to use reusable typed buffers and draw with Canvas.drawRawPoints, reducing per-frame allocations and simplifying drawing logic

Enhancements:
- Rewrite pose overlay painters to accumulate pose and face keypoints into Float32List buffers for raw point drawing
- Introduce _PoseBufferSet and _PointBuffer classes to manage buffer growth and provide typed list views
- Switch SkeletonPainter to use packed typed buffers and Canvas.drawRawPoints instead of dynamic Path and List<Offset>
- Define a constant pose edge index list (_kPoseEdgeIdx) to standardize skeleton connections
- Apply uniform mirroring, scaling, and stroke width adjustments before drawing raw point buffers