### PR TITLE
Add reusable buffers to pose binary parser

### DIFF
--- a/lib/apps/asistente_retratos/infrastructure/parsers/pose_parse_isolate.dart
+++ b/lib/apps/asistente_retratos/infrastructure/parsers/pose_parse_isolate.dart
@@ -1,7 +1,7 @@
 // lib/apps/asistente_retratos/infrastructure/parsers/pose_parse_isolate.dart
 //
 // Isolate de parseo: recibe binarios por SendPort, parsea con PoseBinaryParser
-// (vía parseFlat2D) y devuelve un DTO plano con metadatos + listas Float32List.
+// y devuelve un DTO plano con metadatos + listas Float32List.
 //
 // ENTRADA:
 //   { "type":"job", "task":String, "data":TransferableTypedData, "ackHint":int? }
@@ -61,7 +61,7 @@ void _handleJob(
     final Uint8List buf = ttd.materialize().asUint8List();
     final parser = parsers.putIfAbsent(task, () => PoseBinaryParser());
 
-    final res = parser.parseFlat2D(buf);
+    final res = parser.parse(buf);
 
     if (res is PoseParseOkPacked) {
       reply.send(<String, dynamic>{

--- a/lib/apps/asistente_retratos/infrastructure/services/pose_webrtc_service_imp.dart
+++ b/lib/apps/asistente_retratos/infrastructure/services/pose_webrtc_service_imp.dart
@@ -928,7 +928,13 @@ class PoseWebrtcServiceImp implements PoseCaptureService {
 
   void _handleTaskBinary(String task, Uint8List b) {
     final parser = _parsers.putIfAbsent(task, () => PoseBinaryParser());
-    final res = parser.parseFlat2D(b);
+    final currentLmk = _poseLmk.value;
+    final res = parser.parseIntoFlat2D(
+      b,
+      reusePositions: currentLmk.packedPositions,
+      reuseRanges: currentLmk.packedRanges,
+      reuseZ: currentLmk.packedZPositions,
+    );
 
     if (res is PoseParseOkPacked) {
       final int? seq = res.seq;


### PR DESCRIPTION
## Summary
- add reusable buffer support to `PoseBinaryParser` so callers can parse into reusable XY/Z/range lists
- update the WebRTC binary handler to pass existing landmark buffers as reuse hints
- keep the parse isolate on the allocating code path while updating it to the renamed API

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9929d4b0483298714ae4057128f72

## Summary by Sourcery

Enable optional buffer reuse in PoseBinaryParser to reduce allocations and update consumers to supply reuse hints

New Features:
- Add parseIntoFlat2D method accepting reusable Float32List and Int32List buffers for positions, ranges, and Z

Enhancements:
- Implement internal _ensure and _view methods to manage reusable buffers within the parser
- Update WebRTC service implementation to pass existing landmark buffers as reuse hints when parsing
- Preserve original isolate parsing path by retaining the parse entry point without reuse
- Adjust comments to reflect the API rename