### PR TITLE
Refactor portrait validator into rule-based context

### DIFF
--- a/lib/apps/asistente_retratos/domain/metrics/metrics.dart
+++ b/lib/apps/asistente_retratos/domain/metrics/metrics.dart
@@ -61,6 +61,9 @@ class FrameInputs {
 
 class MetricKeys {
   // Cabeza
+  static const yawSigned = MetricKey('yaw.signed');      // yaw firmado en °
+  static const pitchSigned = MetricKey('pitch.signed');  // pitch firmado en °
+  static const rollSigned = MetricKey('roll.signed');    // roll firmado en °
   static const yawAbs   = MetricKey('yaw.abs');        // |yaw| en ° (abs)
   static const pitchAbs = MetricKey('pitch.abs');      // |pitch| en ° (abs)
   static const rollErr  = MetricKey('roll.err180');    // distancia a 180° (°)

--- a/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
+++ b/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
@@ -600,43 +600,30 @@ extension _OnFrameLogicExt on PoseCaptureController {
     final bool uiEnableAzimut    = !doneNow && (curId == 'azimut') && (azDegHUD != null);
 
     // Ejecuta el validador SOLO para HUD/animaciones (no para gating)
-    final report = _validator.evaluate(
-      faceLandmarksImg: inputs.landmarksImg!, // ya comprobado arriba
-      imageSize: inputs.imageSize,
-      canvasSize: inputs.canvasSize,
-      mirror: inputs.mirror,
-      fit: inputs.fit,
-
-      // Face-in-oval
+    final ctx = PortraitValidationContext(
+      inputs: inputs,
+      metrics: _metricRegistry,
       minFractionInside: p.face.minFractionInside,
       eps: p.face.eps,
-
-      // Yaw/Pitch/Roll (solo si la etapa actual es de cabeza)
       enableYaw: uiEnableYaw,
       yawDeadbandDeg: yawDeadbandNow,
       yawMaxOffDeg: p.yaw.maxOffDeg,
-
       enablePitch: uiEnablePitch,
       pitchDeadbandDeg: pitchDeadbandNow,
       pitchMaxOffDeg: p.pitch.maxOffDeg,
-
       enableRoll: uiEnableRoll,
       rollDeadbandDeg: rollDeadbandNow,
       rollMaxOffDeg: p.roll.maxOffDeg,
-
-      // Shoulders (solo cuando corresponde)
-      poseLandmarksImg: inputs.poseLandmarksImg,
       enableShoulders: uiEnableShoulders,
-      shouldersDeadbandDeg: shouldersTolSymNow, // dinámico simétrico para UI
+      shouldersDeadbandDeg: shouldersTolSymNow,
       shouldersMaxOffDeg: p.shouldersGate.maxOffDeg,
-
-      // Azimut (solo cuando corresponde y hay 3D)
       enableAzimut: uiEnableAzimut,
       azimutDeg: azDegHUD,
       azimutBandLo: azLoNow,
       azimutBandHi: azHiNow,
       azimutMaxOffDeg: p.azimutGate.maxOffDeg,
     );
+    final report = _validator.evaluate(ctx);
 
     final bool faceOk = report.faceInOval;
     final double arcProgress = report.ovalProgress;


### PR DESCRIPTION
## Summary
- add a reusable `PortraitValidationContext`, rule contracts, and map-backed reports for portrait validation
- expose new metric registry keys and providers so yaw/pitch/roll reuse cached head pose data
- update pose capture controller logic to build the new context, consume rule results, and drive the HUD as before

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbfa63a0008329938624535d0b09df

## Summary by Sourcery

Refactor the portrait validator into a context-driven, rule-based system by introducing PortraitValidationContext, rule interfaces, and default rules. Replace the monolithic evaluate method with a dynamic rule engine that produces a map-backed report. Expose new signed yaw/pitch/roll metrics in the MetricRegistry and update the PoseCaptureController to instantiate and consume the new validator and context for HUD logic.

New Features:
- Introduce PortraitValidationContext and PortraitRule contract for rule-based portrait validation
- Implement default portrait rules (face in oval, yaw, pitch, roll, shoulders, azimut) with RuleResult reporting
- Add signed yaw, pitch, and roll metric keys to MetricRegistry with corresponding providers

Enhancements:
- Refactor PortraitValidator to apply a dynamic list of rules from context and emit a map-backed PortraitValidationReport
- Update PoseCaptureController to build the new validation context and use the rule engine for HUD updates