### PR TITLE
Enable face recognition task negotiation

### DIFF
--- a/lib/apps/asistente_retratos/dependencias_posture.dart
+++ b/lib/apps/asistente_retratos/dependencias_posture.dart
@@ -22,6 +22,8 @@ void registrarDependenciasPosture({
     () => PoseWebrtcServiceImp(
       offerUri: offerUri,
       logEverything: logEverything,
+      requestedTasks: const ['pose', 'face', 'face_recog'],
+      jsonTasks: const {'face_recog'},
     ),
   );
   sl.registerLazySingleton<PoseCaptureService>(


### PR DESCRIPTION
## Summary
- request the pose, face, and face_recog tasks when wiring the WebRTC service dependencies
- normalize and forward face_recog task parameters with the WebRTC offer payload when provided

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd61167edc8329885ff50ddeb2a6ff

## Summary by Sourcery

Enable negotiation of the face_recog task in the WebRTC service by extending the PoseWebrtcServiceImp constructor to accept and forward initial task parameters, and update dependency registration to include face_recog in the requested tasks.

New Features:
- Add support for initial task parameters in PoseWebrtcServiceImp and include normalized task_params in the WebRTC offer payload
- Enable face_recog task negotiation by default by adding 'face_recog' to the requestedTasks and jsonTasks dependencies

Enhancements:
- Normalize and filter provided task parameter keys before forwarding in the offer payload