### PR TITLE
Handle face recognition JSON updates

### DIFF
--- a/lib/apps/asistente_retratos/domain/model/face_recog_result.dart
+++ b/lib/apps/asistente_retratos/domain/model/face_recog_result.dart
@@ -1,0 +1,15 @@
+// lib/apps/asistente_retratos/domain/model/face_recog_result.dart
+
+class FaceRecogResult {
+  const FaceRecogResult({
+    required this.seq,
+    required this.ts,
+    this.cosSim,
+    this.decision,
+  });
+
+  final double? cosSim;
+  final String? decision;
+  final int seq;
+  final DateTime ts;
+}

--- a/lib/apps/asistente_retratos/infrastructure/parsers/pose_json_parser.dart
+++ b/lib/apps/asistente_retratos/infrastructure/parsers/pose_json_parser.dart
@@ -142,6 +142,16 @@ class PoseJsonParser {
       return;
     }
 
+    if (cosSim != null || (decision != null && decision.isNotEmpty)) {
+      final payload = <String, dynamic>{'seq': seq};
+      if (cosSim != null) payload['cos_sim'] = cosSim;
+      if (decision != null && decision.isNotEmpty) {
+        payload['decision'] = decision;
+      }
+      deliverTaskJsonEvent(task, payload);
+      return;
+    }
+
     warn('JSON $task normalizado pero sin kpts ni embedding');
   }
 


### PR DESCRIPTION
## Summary
- ensure face recognition JSON events still emit when only similarity or decision metadata is present
- add a FaceRecogResult model and ValueNotifier to expose the latest face recognition result
- populate the notifier when face_recog events arrive before forwarding the payload stream

## Testing
- Not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd63f816308329887c43e6596bf4f0

## Summary by Sourcery

Expose face recognition metadata through a new result model and notifier, and update JSON parsing to emit face_recog events even when only similarity score or decision data is present

New Features:
- Introduce FaceRecogResult model and faceRecogResult ValueNotifier in PoseWebrtcServiceImp to expose the latest face recognition outcome

Enhancements:
- Emit face_recog JSON events when only cos_sim or decision fields are present
- Add robust parsing of cos_sim, decision, and seq fields before updating the notifier and forwarding events