### PR TITLE
Integrate face recognition gating into pose capture

### DIFF
--- a/lib/apps/asistente_retratos/domain/service/pose_capture_service.dart
+++ b/lib/apps/asistente_retratos/domain/service/pose_capture_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter_webrtc/flutter_webrtc.dart' show RTCVideoRenderer, MediaStream;
 
 import '../model/lmk_state.dart'; // ⬅️ añade esto
+import '../model/face_recog_result.dart';
 
 import '../../infrastructure/model/pose_frame.dart' show PoseFrame;
 import '../../infrastructure/model/pose_point.dart' show PosePoint;
@@ -33,4 +34,6 @@ abstract class PoseCaptureService {
   ValueListenable<LmkState> get faceLandmarks;
   // ⬅️ NUEVO: POSE landmarks para usar con PosePainter
   ValueListenable<LmkState> get poseLandmarks;
+
+  ValueListenable<FaceRecogResult?> get faceRecogResult;
 }

--- a/lib/apps/asistente_retratos/infrastructure/services/pose_webrtc_service_imp.dart
+++ b/lib/apps/asistente_retratos/infrastructure/services/pose_webrtc_service_imp.dart
@@ -360,6 +360,7 @@ class PoseWebrtcServiceImp implements PoseCaptureService {
 
   final ValueNotifier<FaceRecogResult?> _faceRecogResult =
       ValueNotifier<FaceRecogResult?>(null);
+  @override
   ValueListenable<FaceRecogResult?> get faceRecogResult => _faceRecogResult;
 
   final ValueNotifier<LmkState> _poseLmk = ValueNotifier<LmkState>(LmkState());


### PR DESCRIPTION
## Summary
- expose the face recognition result through `PoseCaptureService` and mark the override in the WebRTC implementation
- subscribe to face recognition updates inside `PoseCaptureController` to persist match/score and clean up on dispose
- gate the HUD/countdown with the face recognition status and show explicit messages while the result is pending or not a match

## Testing
- not run (flutter tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dd6640e5a88329bf4d0e1dffa7411c

## Summary by Sourcery

Integrate face recognition gating into the pose capture flow by exposing recognition results from the service, subscribing to updates in the controller, and gating the HUD and countdown based on match status with explicit user messages.

New Features:
- Expose faceRecogResult ValueListenable in PoseCaptureService and its WebRTC implementation
- Subscribe to face recognition updates in PoseCaptureController to track match status, raw decision, and score

Enhancements:
- Gate HUD and countdown on face recognition match status alongside existing face and pose checks
- Show explicit pending, match, and no-match messages (including score) via a new helper