### PR TITLE
Set face recognition reference image parameter

### DIFF
--- a/lib/apps/asistente_retratos/dependencias_posture.dart
+++ b/lib/apps/asistente_retratos/dependencias_posture.dart
@@ -24,6 +24,9 @@ void registrarDependenciasPosture({
       logEverything: logEverything,
       requestedTasks: const ['pose', 'face', 'face_recog'],
       jsonTasks: const {'face_recog'},
+      initialTaskParams: const {
+        'face_recog': {'ref_image_path': '1050298650'},
+      },
     ),
   );
   sl.registerLazySingleton<PoseCaptureService>(


### PR DESCRIPTION
## Summary
- pass the face recognition reference image parameter when registering the WebRTC service so the backend receives ref_image_path

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6c8bb8bc8329a977e35eb8f5e845

## Summary by Sourcery

Enhancements:
- Pass `initialTaskParams` with `ref_image_path` for the face recognition task during service registration