### PR TITLE
Add logEverything plumbing to pose capture controller

### DIFF
--- a/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.dart
+++ b/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.dart
@@ -376,6 +376,7 @@ class PoseCaptureController extends ChangeNotifier {
     required this.countdownSpeed,
     this.mirror = true,
     this.validationsEnabled = true, // ⇠ NEW
+    this.logEverything = false,
     ValidationProfile? validationProfile, // ⇠ NEW: inject data-driven thresholds
   })  : assert(countdownFps > 0, 'countdownFps must be > 0'),
         assert(countdownSpeed > 0, 'countdownSpeed must be > 0'),
@@ -464,6 +465,8 @@ class PoseCaptureController extends ChangeNotifier {
 
   /// NEW: switch global de validaciones
   final bool validationsEnabled;
+
+  final bool logEverything;
 
   /// ⇠ NEW: Perfil de validación inyectado (bandas y deadbands data-driven)
   final ValidationProfile profile;

--- a/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
+++ b/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
@@ -1,8 +1,8 @@
 // lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
 part of 'pose_capture_controller.dart';
 
-void _poseCtrlLog(String message) {
-  if (kDebugMode) {
+void _poseCtrlLog(PoseCaptureController ctrl, String message) {
+  if (kDebugMode || ctrl.logEverything) {
     debugPrint('[PoseCapture] $message');
   }
 }
@@ -512,13 +512,13 @@ extension _OnFrameLogicExt on PoseCaptureController {
     final pose = poseService.latestPoseLandmarks; // image-space points
     final lms3d = poseService.latestPoseLandmarks3D; // List<PosePoint>?
     if (canvas == null) {
-      _poseCtrlLog('Skipping frame: canvas size not ready yet');
+      _poseCtrlLog(this, 'Skipping frame: canvas size not ready yet');
       return null;
     }
     if (faces == null || faces.isEmpty) {
       final poseCount = pose?.length ?? 0;
       _poseCtrlLog(
-          'Skipping frame: no face landmarks (poseLandmarks=$poseCount)');
+          this, 'Skipping frame: no face landmarks (poseLandmarks=$poseCount)');
       return null;
     }
 
@@ -656,10 +656,12 @@ extension _OnFrameLogicExt on PoseCaptureController {
 
     if (pose == null || pose.isEmpty) {
       _poseCtrlLog(
+          this,
           'Frame ${now.millisecondsSinceEpoch}: pose landmarks missing; relying on face only');
     }
 
     _poseCtrlLog(
+      this,
       'Frame ${now.millisecondsSinceEpoch}: Δt=${dtMs.toStringAsFixed(1)}ms, '
       'faceOk=$faceOk, arc=${arcProgress.toStringAsFixed(2)}, '
       'yaw=${rawYaw.toStringAsFixed(2)}→${_emaYawDeg?.toStringAsFixed(2)}, '

--- a/lib/apps/asistente_retratos/presentation/pages/pose_capture_page.dart
+++ b/lib/apps/asistente_retratos/presentation/pages/pose_capture_page.dart
@@ -56,6 +56,9 @@ class _PoseCapturePageState extends State<PoseCapturePage> {
   @override
   void initState() {
     super.initState();
+    final logAll = widget.poseService is PoseWebrtcServiceImp
+        ? (widget.poseService as PoseWebrtcServiceImp).logEverything
+        : false;
     ctl = PoseCaptureController(
       poseService: widget.poseService,
       countdownDuration: widget.countdownDuration,
@@ -63,6 +66,7 @@ class _PoseCapturePageState extends State<PoseCapturePage> {
       countdownSpeed: widget.countdownSpeed,
       mirror: true,
       validationsEnabled: widget.validationsEnabled,
+      logEverything: logAll,
     );
     ctl.setFallbackSnapshot(_captureSnapshotBytes);
     ctl.attach();


### PR DESCRIPTION
## Summary
- add an optional `logEverything` flag to `PoseCaptureController` and store it
- gate `_poseCtrlLog` output on both `kDebugMode` and the controller flag and pass the controller instance
- read `logEverything` from `PoseWebrtcServiceImp` when constructing the controller on the pose capture page

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde4b4b3788329be48b5a4848c6b2d

## Summary by Sourcery

Enable an optional `logEverything` mode in the pose capture controller and wire it through the logging function and page setup to allow forced logging regardless of build mode.

New Features:
- Introduce a `logEverything` flag on PoseCaptureController to toggle detailed frame logging

Enhancements:
- Modify `_poseCtrlLog` to accept a controller instance and respect `logEverything` alongside debug mode
- Update all invocations of `_poseCtrlLog` to pass the controller reference
- Read and forward `logEverything` from PoseWebrtcServiceImp when constructing the controller on the pose capture page