### PR TITLE
chore: gate pose capture logs by flag

### DIFF
--- a/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
+++ b/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
@@ -2,7 +2,7 @@
 part of 'pose_capture_controller.dart';
 
 void _poseCtrlLog(PoseCaptureController ctrl, String message) {
-  if (kDebugMode || ctrl.logEverything) {
+  if (ctrl.logEverything) {
     debugPrint('[PoseCapture] $message');
   }
 }


### PR DESCRIPTION
## Summary
- ensure pose capture logging is controlled exclusively by the logEverything flag

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea72ecd9c832991dc890f835c373a

## Summary by Sourcery

Enhancements:
- Restrict pose capture logging to occur only when logEverything is enabled