### PR TITLE
Add captured portrait download button

### DIFF
--- a/lib/apps/asistente_retratos/presentation/pages/pose_capture_page.dart
+++ b/lib/apps/asistente_retratos/presentation/pages/pose_capture_page.dart
@@ -22,6 +22,7 @@ import '../widgets/frame_sequence_overlay.dart' show FrameSequenceOverlay;
 import '../../core/face_oval_geometry.dart' show faceOvalRectFor;
 
 import '../controllers/pose_capture_controller.dart';
+import '../utils/capture_downloader.dart' show saveCapturedPortrait;
 
 // ✅ acceso a CaptureTheme (para color de landmarks)
 import 'package:validador_retratos_flutter/apps/asistente_retratos/presentation/styles/colors.dart'
@@ -89,6 +90,26 @@ class _PoseCapturePageState extends State<PoseCapturePage> {
     final ui.Image image = await boundary.toImage(pixelRatio: dpr);
     final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
     return byteData?.buffer.asUint8List();
+  }
+
+  Future<void> _downloadCaptured() async {
+    final bytes = ctl.capturedPng;
+    if (bytes == null) return;
+
+    final filename = 'retrato_${DateTime.now().millisecondsSinceEpoch}.png';
+    final success = await saveCapturedPortrait(bytes, filename: filename);
+    if (!mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(
+          success
+              ? 'Descarga iniciada. Revisa tu carpeta de descargas.'
+              : 'La descarga no está disponible en esta plataforma.',
+        ),
+      ),
+    );
   }
 
   @override
@@ -254,14 +275,30 @@ class _PoseCapturePageState extends State<PoseCapturePage> {
                               ),
                             ),
                             Positioned(
+                              bottom: 32,
+                              left: 0,
+                              right: 0,
+                              child: SafeArea(
+                                child: Center(
+                                  child: FilledButton.icon(
+                                    onPressed: _downloadCaptured,
+                                    icon: const Icon(Icons.download),
+                                    label: const Text('Descargar foto'),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            Positioned(
                               top: 16,
                               right: 16,
                               child: Material(
                                 color: scheme.primary.withOpacity(0.92),
                                 shape: const CircleBorder(),
                                 child: IconButton(
-                                  icon: Icon(Icons.close,
-                                      color: scheme.onPrimary),
+                                  icon: Icon(
+                                    Icons.close,
+                                    color: scheme.onPrimary,
+                                  ),
                                   onPressed: ctl.closeCaptured,
                                   tooltip: 'Cerrar',
                                 ),

--- a/lib/apps/asistente_retratos/presentation/utils/capture_downloader.dart
+++ b/lib/apps/asistente_retratos/presentation/utils/capture_downloader.dart
@@ -1,0 +1,11 @@
+import 'dart:typed_data';
+
+import 'capture_downloader_stub.dart'
+    if (dart.library.html) 'capture_downloader_web.dart' as impl;
+
+Future<bool> saveCapturedPortrait(
+  Uint8List bytes, {
+  String filename = 'retrato.png',
+}) {
+  return impl.saveCaptured(bytes, filename: filename);
+}

--- a/lib/apps/asistente_retratos/presentation/utils/capture_downloader_stub.dart
+++ b/lib/apps/asistente_retratos/presentation/utils/capture_downloader_stub.dart
@@ -1,0 +1,5 @@
+import 'dart:typed_data';
+
+Future<bool> saveCaptured(Uint8List bytes, {required String filename}) async {
+  return false;
+}

--- a/lib/apps/asistente_retratos/presentation/utils/capture_downloader_web.dart
+++ b/lib/apps/asistente_retratos/presentation/utils/capture_downloader_web.dart
@@ -1,0 +1,16 @@
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+Future<bool> saveCaptured(Uint8List bytes, {required String filename}) async {
+  final blob = html.Blob([bytes]);
+  final url = html.Url.createObjectUrlFromBlob(blob);
+  final anchor = html.AnchorElement(href: url)
+    ..download = filename
+    ..style.display = 'none';
+  html.document.body?.append(anchor);
+  anchor.click();
+  anchor.remove();
+  html.Url.revokeObjectUrl(url);
+  return true;
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to initiate portrait downloads with a web implementation and safe fallback
- surface a download button over the captured preview so the user can save the portrait when validations finish

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfdca0524083298b43d30b68bc45dc