### PR TITLE
Rename pose capture service to portrait validations service

### DIFF
--- a/lib/apps/asistente_retratos/dependencias_posture.dart
+++ b/lib/apps/asistente_retratos/dependencias_posture.dart
@@ -1,11 +1,11 @@
 // lib/apps/asistente_retratos/dependencias_posture.dart
 import 'package:get_it/get_it.dart';
 
-import 'domain/service/pose_capture_service.dart';
+import 'domain/service/portrait_validations_capture_service.dart';
 import 'domain/repository/posture_repository.dart';
 //import 'domain/service/evaluate_frame_usecase.dart';
 
-import 'infrastructure/services/pose_webrtc_service_imp.dart';
+import 'infrastructure/services/portrait_webrtc_service_imp.dart';
 import 'infrastructure/repository/posture_repository_imp.dart';
 
 final sl = GetIt.instance;
@@ -18,8 +18,8 @@ void registrarDependenciasPosture({
 }) {
   // Service (infra) — registra UNA sola instancia y expón tanto el contrato
   // como la implementación (útil si tu repo aún depende de la clase concreta).
-  sl.registerLazySingleton<PoseWebrtcServiceImp>(
-    () => PoseWebrtcServiceImp(
+  sl.registerLazySingleton<PortraitWebrtcServiceImp>(
+    () => PortraitWebrtcServiceImp(
       offerUri: offerUri,
       logEverything: logEverything,
       requestedTasks: const ['pose', 'face', 'face_recog'],
@@ -29,14 +29,14 @@ void registrarDependenciasPosture({
       },
     ),
   );
-  sl.registerLazySingleton<PoseCaptureService>(
-    () => sl<PoseWebrtcServiceImp>(),
+  sl.registerLazySingleton<PortraitValidationsCaptureService>(
+    () => sl<PortraitWebrtcServiceImp>(),
   );
 
   // Repository
   sl.registerLazySingleton<PostureRepository>(
     () => PostureRepositoryImp(
-      sl<PoseWebrtcServiceImp>(), // si tu repo acepta el contrato, usa: sl<PoseCaptureService>()
+      sl<PortraitWebrtcServiceImp>(), // si tu repo acepta el contrato, usa: sl<PortraitValidationsCaptureService>()
     ),
   );
 

--- a/lib/apps/asistente_retratos/domain/service/portrait_validations_capture_service.dart
+++ b/lib/apps/asistente_retratos/domain/service/portrait_validations_capture_service.dart
@@ -1,4 +1,4 @@
-// lib/apps/asistente_retratos/domain/service/pose_capture_service.dart
+// lib/apps/asistente_retratos/domain/service/portrait_validations_capture_service.dart
 import 'dart:async';
 import 'dart:ui' show Offset;
 import 'package:flutter/foundation.dart' show ValueListenable;
@@ -10,7 +10,7 @@ import '../model/face_recog_result.dart';
 import '../../infrastructure/model/pose_frame.dart' show PoseFrame;
 import '../../infrastructure/model/pose_point.dart' show PosePoint;
 
-abstract class PoseCaptureService {
+abstract class PortraitValidationsCaptureService {
   Future<void> init();
   Future<void> connect();
   Future<void> switchCamera();

--- a/lib/apps/asistente_retratos/infrastructure/repository/posture_repository_imp.dart
+++ b/lib/apps/asistente_retratos/infrastructure/repository/posture_repository_imp.dart
@@ -2,10 +2,10 @@
 import 'dart:async';
 import 'dart:typed_data';
 import '../../domain/repository/posture_repository.dart';
-import '../../domain/service/pose_capture_service.dart';
+import '../../domain/service/portrait_validations_capture_service.dart';
 
 class PostureRepositoryImp implements PostureRepository {
-  final PoseCaptureService _webrtc;
+  final PortraitValidationsCaptureService _webrtc;
   PostureRepositoryImp(this._webrtc);
 
   final _aliveCtrl = StreamController<bool>.broadcast();

--- a/lib/apps/asistente_retratos/infrastructure/services/portrait_webrtc_service_imp.dart
+++ b/lib/apps/asistente_retratos/infrastructure/services/portrait_webrtc_service_imp.dart
@@ -1,4 +1,4 @@
-// lib/apps/asistente_retratos/infrastructure/services/pose_webrtc_service_imp.dart
+// lib/apps/asistente_retratos/infrastructure/services/portrait_webrtc_service_imp.dart
 
 import 'dart:async';
 import 'dart:convert' show jsonDecode, jsonEncode, utf8;
@@ -12,7 +12,7 @@ import 'package:flutter/foundation.dart'
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'package:http/http.dart' as http;
 
-import '../../domain/service/pose_capture_service.dart';
+import '../../domain/service/portrait_validations_capture_service.dart';
 import '../../domain/model/lmk_state.dart';
 import '../../domain/model/face_recog_result.dart';
 import '../model/pose_frame.dart' show PoseFrame;
@@ -140,8 +140,8 @@ int _dcIdFromTask(String name, {int mod = 1024}) {
   return id;
 }
 
-class PoseWebrtcServiceImp implements PoseCaptureService {
-  PoseWebrtcServiceImp({
+class PortraitWebrtcServiceImp implements PortraitValidationsCaptureService {
+  PortraitWebrtcServiceImp({
     required this.offerUri,
     this.facingMode = 'user',
     this.idealWidth = 640,
@@ -215,11 +215,11 @@ class PoseWebrtcServiceImp implements PoseCaptureService {
 
   void _log(String message) {
     if (!logEverything) return;
-    debugPrint('[PoseWebRTC] $message');
+    debugPrint('[PortraitWebRTC] $message');
   }
 
   void _warn(String message) {
-    debugPrint('[PoseWebRTC][WARN] $message');
+    debugPrint('[PortraitWebRTC][WARN] $message');
   }
 
   String get _primaryTask =>

--- a/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.dart
+++ b/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.dart
@@ -10,7 +10,7 @@ import 'package:flutter_webrtc/flutter_webrtc.dart';
 import 'dart:ui' show Size, Offset;
 import 'package:flutter/painting.dart' show BoxFit;
 
-import '../../domain/service/pose_capture_service.dart';
+import '../../domain/service/portrait_validations_capture_service.dart';
 import '../../domain/model/face_recog_result.dart';
 import '../widgets/portrait_validator_hud.dart'
     show PortraitValidatorHUD, PortraitUiController, PortraitUiModel, Tri;
@@ -325,7 +325,7 @@ class _Countdown {
 /// Pipeline de captura (WebRTC → fallback)
 class _Capture {
   static Future<Uint8List?> tryAll(
-    PoseCaptureService svc,
+    PortraitValidationsCaptureService svc,
     SnapshotFn? fallback,
   ) async {
     // 1) WebRTC track
@@ -457,7 +457,7 @@ class PoseCaptureController extends ChangeNotifier {
   }
 
   // ── External deps/config ──────────────────────────────────────────────
-  final PoseCaptureService poseService;
+  final PortraitValidationsCaptureService poseService;
   final Duration countdownDuration;
   final int countdownFps;
   final double countdownSpeed;

--- a/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
+++ b/lib/apps/asistente_retratos/presentation/controllers/pose_capture_controller.onframe.dart
@@ -3,7 +3,7 @@ part of 'pose_capture_controller.dart';
 
 void _poseCtrlLog(PoseCaptureController ctrl, String message) {
   if (ctrl.logEverything) {
-    debugPrint('[PoseCapture] $message');
+    debugPrint('[PortraitValidationsCapture] $message');
   }
 }
 

--- a/lib/apps/asistente_retratos/presentation/pages/pose_capture_page.dart
+++ b/lib/apps/asistente_retratos/presentation/pages/pose_capture_page.dart
@@ -9,13 +9,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderRepaintBoundary;
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
-import '../../domain/service/pose_capture_service.dart';
+import '../../domain/service/portrait_validations_capture_service.dart';
 
 // ✅ agrega:
 import '../widgets/landmarks_painter.dart' show LandmarksPainter, FaceStyle;
 // (si tu painter usa directamente la impl del servicio)
-import '../../infrastructure/services/pose_webrtc_service_imp.dart'
-    show PoseWebrtcServiceImp;
+import '../../infrastructure/services/portrait_webrtc_service_imp.dart'
+    show PortraitWebrtcServiceImp;
 
 import '../widgets/portrait_validator_hud.dart' show PortraitValidatorHUD;
 import '../widgets/frame_sequence_overlay.dart' show FrameSequenceOverlay;
@@ -39,7 +39,7 @@ class PoseCapturePage extends StatefulWidget {
     this.drawLandmarks = true, // ⬅️ nuevo
   });
 
-  final PoseCaptureService poseService;
+  final PortraitValidationsCaptureService poseService;
   final Duration countdownDuration;
   final int countdownFps;
   final double countdownSpeed;
@@ -57,8 +57,8 @@ class _PoseCapturePageState extends State<PoseCapturePage> {
   @override
   void initState() {
     super.initState();
-    final logAll = widget.poseService is PoseWebrtcServiceImp
-        ? (widget.poseService as PoseWebrtcServiceImp).logEverything
+    final logAll = widget.poseService is PortraitWebrtcServiceImp
+        ? (widget.poseService as PortraitWebrtcServiceImp).logEverything
         : false;
     ctl = PoseCaptureController(
       poseService: widget.poseService,
@@ -140,9 +140,9 @@ class _PoseCapturePageState extends State<PoseCapturePage> {
                         child: IgnorePointer(
                           child: Builder(
                             builder: (_) {
-                              // si el servicio concreto es PoseWebrtcServiceImp, úsalo directo
-                              final impl = widget.poseService is PoseWebrtcServiceImp
-                                  ? widget.poseService as PoseWebrtcServiceImp
+                              // si el servicio concreto es PortraitWebrtcServiceImp, úsalo directo
+                              final impl = widget.poseService is PortraitWebrtcServiceImp
+                                  ? widget.poseService as PortraitWebrtcServiceImp
                                   : null;
 
                               final hasPainter = widget.drawLandmarks && impl != null;

--- a/lib/apps/asistente_retratos/presentation/widgets/landmarks_painter.dart
+++ b/lib/apps/asistente_retratos/presentation/widgets/landmarks_painter.dart
@@ -4,7 +4,7 @@ import 'dart:ui' as ui show PointMode;
 import 'package:flutter/widgets.dart';
 
 import '../../domain/model/lmk_state.dart';
-import '../../infrastructure/services/pose_webrtc_service_imp.dart';
+import '../../infrastructure/services/portrait_webrtc_service_imp.dart';
 import '../styles/colors.dart'
     show CaptureTheme;
 
@@ -53,7 +53,7 @@ class LandmarksPainter extends CustomPainter {
   }
 
   // Fuente de datos
-  final PoseWebrtcServiceImp service;
+  final PortraitWebrtcServiceImp service;
 
   // Tema de captura (fuente ÚNICA del color de landmarks)
   final CaptureTheme cap;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart'; // ⬅️ para FlutterError, debugPrin
 import 'package:get_it/get_it.dart';
 
 import 'apps/asistente_retratos/dependencias_posture.dart';
-import 'apps/asistente_retratos/domain/service/pose_capture_service.dart';
+import 'apps/asistente_retratos/domain/service/portrait_validations_capture_service.dart';
 import 'apps/asistente_retratos/presentation/pages/pose_capture_page.dart';
 import 'apps/asistente_retratos/presentation/styles/theme.dart';
 
@@ -44,7 +44,7 @@ Future<void> main() async {
     );
 
     // 2) Obtener el servicio por contrato e iniciarlo
-    final poseService = GetIt.I<PoseCaptureService>();
+    final poseService = GetIt.I<PortraitValidationsCaptureService>();
     await poseService.init();
     unawaited(poseService.connect());
 
@@ -66,7 +66,7 @@ class PoseApp extends StatefulWidget {
     required this.validationsEnabled,
   });
 
-  final PoseCaptureService service;
+  final PortraitValidationsCaptureService service;
   final bool validationsEnabled;
 
   @override


### PR DESCRIPTION
## Summary
- rename the pose capture domain service to `PortraitValidationsCaptureService` and update all consumers
- rename the WebRTC infrastructure implementation to `PortraitWebrtcServiceImp` and align GetIt registrations
- refresh logging labels and imports in presentation layers to reference the new portrait validations nomenclature

## Testing
- flutter analyze *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a07f26848329a0094cac38be852d

## Summary by Sourcery

Rename pose capture service and related WebRTC implementation to portrait validations nomenclature across domain, infrastructure, presentation, and GetIt registrations.

Enhancements:
- Rename PoseCaptureService to PortraitValidationsCaptureService and update all references and imports.
- Rename PoseWebrtcServiceImp to PortraitWebrtcServiceImp with aligned filenames and class names.
- Refresh logging labels and GetIt dependency registrations to use the new portrait validations wording.