### PR TITLE
Optimize parse isolate messaging

### DIFF
--- a/lib/apps/asistente_retratos/infrastructure/parsers/pose_parse_isolate.dart
+++ b/lib/apps/asistente_retratos/infrastructure/parsers/pose_parse_isolate.dart
@@ -64,47 +64,31 @@ void _handleJob(
     final res = parser.parse(buf);
 
     if (res is PoseParseOkPacked) {
-      reply.send(<String, dynamic>{
-        'type': 'result',
-        'status': 'ok',
-        'task': task,
-        'w': res.w,
-        'h': res.h,
-        'seq': res.seq,
-        'ackSeq': res.ackSeq,
-        'requestKF': res.requestKeyframe,
-        'keyframe': res.keyframe,
-        'kind': res.kind == PacketKind.po ? 'PO' : 'PD',
-        'positions': res.positions,
-        'ranges': res.ranges,
-        'hasZ': res.hasZ,
-        if (res.zPositions != null) 'zPositions': res.zPositions,
-      });
+      reply.send(<dynamic>[
+        0, // status: ok
+        task,
+        res.w,
+        res.h,
+        res.seq,
+        res.ackSeq,
+        res.requestKeyframe,
+        res.keyframe,
+        res.kind == PacketKind.po ? 0 : 1,
+        res.positions,
+        res.ranges,
+        res.hasZ,
+        res.zPositions,
+      ]);
       return;
     }
 
     if (res is PoseParseNeedKF) {
-      reply.send(<String, dynamic>{
-        'type': 'result',
-        'status': 'need_kf',
-        'task': (msg['task'] as String?) ?? 'pose',
-        'error': res.reason,
-      });
+      reply.send(<dynamic>[1, task, res.reason]);
       return;
     }
 
-    reply.send(<String, dynamic>{
-      'type': 'result',
-      'status': 'err',
-      'task': (msg['task'] as String?) ?? 'pose',
-      'error': 'Unknown parse result type',
-    });
+    reply.send(<dynamic>[2, task, 'Unknown parse result type']);
   } catch (e) {
-    reply.send(<String, dynamic>{
-      'type': 'result',
-      'status': 'err',
-      'task': (msg['task'] as String?) ?? 'pose',
-      'error': e.toString(),
-    });
+    reply.send(<dynamic>[2, (msg['task'] as String?) ?? 'pose', e.toString()]);
   }
 }


### PR DESCRIPTION
## Summary
- encode parse isolate responses as positional lists to shrink allocation costs and GC pressure
- decode packed isolate payloads in the main service with shared handling while keeping legacy Map support
- maintain parse scheduling/backpressure while updating keyframe/error handling for the new result format

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e592d498f48329af50329882a68f28

## Summary by Sourcery

Optimize messaging between the parse isolate and main service by switching to positional list payloads to reduce allocations and GC pressure, while maintaining legacy map support and preserving scheduling, backpressure, and keyframe/error handling.

Enhancements:
- Encode parse isolate responses as positional lists to reduce allocation and GC overhead
- Introduce packet field index constants and consolidate payload processing into a unified handler
- Support decoding of both packed list payloads and legacy map payloads with fallback for backward compatibility
- Update parse result dispatch logic to handle new list format, preserving ack sequencing, backpressure, and keyframe/error handling